### PR TITLE
Review follow-ups: site fixes + full Swift 6 concurrency hardening + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select latest Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,18 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: macos-15
+    # macos-26 ships the macOS 26 SDK, which is required: MetricsService uses
+    # MetricKit payload APIs (MXMetricPayload/MXDiagnosticPayload) that are
+    # unavailable in the macOS 15.x SDK shipped with older Xcodes (e.g. 16.2).
+    runs-on: macos-26
     timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select latest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
 
       - name: Show versions
         run: |

--- a/TrimrPix/Models/Settings.swift
+++ b/TrimrPix/Models/Settings.swift
@@ -26,7 +26,10 @@ enum CompressionPreset: String, CaseIterable {
 }
 
 /// Application settings management
-/// Implements SettingsProtocol for dependency injection and testing
+/// Implements SettingsProtocol for dependency injection and testing.
+/// `@MainActor`-isolated: settings are owned by the UI; background work reads an
+/// immutable `CompressionSettings` snapshot instead of this mutable type.
+@MainActor
 final class Settings: SettingsProtocol {
     
     // MARK: - Published Properties

--- a/TrimrPix/Services/CompressionService.swift
+++ b/TrimrPix/Services/CompressionService.swift
@@ -18,24 +18,22 @@ import UniformTypeIdentifiers
 final class CompressionService: CompressionServiceProtocol, @unchecked Sendable {
     
     // MARK: - Dependencies
-    
-    private let settings: any SettingsProtocol
+
     private let fileManager: any FileManagerProtocol
     private let logger: any LoggerProtocol
-    
+
     // MARK: - Initialization
-    
-    /// Initializes the compression service with dependencies
+
+    /// Initializes the compression service with dependencies.
+    /// Settings are not held here — they are passed per call as a `CompressionSettings`
+    /// snapshot so the service stays stateless and free of cross-actor reads.
     /// - Parameters:
-    ///   - settings: Settings protocol instance (defaults to Settings.shared)
     ///   - fileManager: File manager protocol instance (defaults to FileManager.default)
     ///   - logger: Logger protocol instance (defaults to Logger.shared)
     init(
-        settings: any SettingsProtocol = Settings.shared,
         fileManager: any FileManagerProtocol = FileManager.default,
         logger: any LoggerProtocol = Logger.shared
     ) {
-        self.settings = settings
         self.fileManager = fileManager
         self.logger = logger
     }
@@ -43,10 +41,12 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     // MARK: - Public Methods
     
     /// Optimizes an image at the given URL
-    /// - Parameter url: The URL of the image to optimize
+    /// - Parameters:
+    ///   - url: The URL of the image to optimize
+    ///   - settings: A Sendable snapshot of the settings to use
     /// - Returns: The URL of the optimized image
     /// - Throws: TrimrPixError if optimization fails
-    func optimizeImage(at url: URL) async throws -> URL {
+    func optimizeImage(at url: URL, settings: CompressionSettings) async throws -> URL {
         logger.info("Starting image optimization for: \(url.lastPathComponent)")
         
         // Determine file type using UTType for better detection
@@ -76,7 +76,7 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
         // Optimize image based on file type
         var optimizedData: Data
         do {
-            optimizedData = try await optimizeImageData(at: url, fileExtension: fileExtension)
+            optimizedData = try await optimizeImageData(at: url, fileExtension: fileExtension, settings: settings)
         } catch let error as TrimrPixError {
             logger.error("Compression failed: \(error.technicalDescription)")
             throw error
@@ -126,20 +126,20 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     ///   - fileExtension: The file extension (lowercased)
     /// - Returns: The optimized image data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizeImageData(at url: URL, fileExtension: String) async throws -> Data {
+    private func optimizeImageData(at url: URL, fileExtension: String, settings: CompressionSettings) async throws -> Data {
         switch fileExtension {
         case "jpg", "jpeg":
-            return try await optimizeJPEGData(at: url)
+            return try await optimizeJPEGData(at: url, settings: settings)
         case "png":
-            return try await optimizePNGData(at: url)
+            return try await optimizePNGData(at: url, settings: settings)
         case "gif":
             return try await optimizeGIFData(at: url)
         case "webp":
-            return try await optimizeWebPData(at: url)
+            return try await optimizeWebPData(at: url, settings: settings)
         case "avif":
-            return try await optimizeAVIFData(at: url)
+            return try await optimizeAVIFData(at: url, settings: settings)
         case "heic", "heif":
-            return try await optimizeHEICData(at: url)
+            return try await optimizeHEICData(at: url, settings: settings)
         default:
             let error = TrimrPixError.unsupportedImageFormat(fileExtension)
             logger.warning("Unsupported format: \(error.technicalDescription)")
@@ -151,7 +151,7 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     /// - Parameter url: The URL of the JPEG image
     /// - Returns: The optimized JPEG data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizeJPEGData(at url: URL) async throws -> Data {
+    private func optimizeJPEGData(at url: URL, settings: CompressionSettings) async throws -> Data {
         logger.debug("Optimizing JPEG: \(url.lastPathComponent)")
 
         let extraOptions: [CFString: Any] = [
@@ -162,6 +162,7 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
 
         return try await compressWithCGImageDestination(
             at: url, type: .jpeg,
+            settings: settings,
             extraOptions: extraOptions,
             errorFactory: TrimrPixError.jpegCompressionFailed
         )
@@ -171,10 +172,10 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     /// - Parameter url: The URL of the PNG image
     /// - Returns: The optimized PNG data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizePNGData(at url: URL) async throws -> Data {
+    private func optimizePNGData(at url: URL, settings: CompressionSettings) async throws -> Data {
         logger.debug("Optimizing PNG: \(url.lastPathComponent)")
 
-        let cgImage = try loadImage(at: url, errorFactory: TrimrPixError.pngCompressionFailed)
+        let cgImage = try loadImage(at: url, settings: settings, errorFactory: TrimrPixError.pngCompressionFailed)
 
         // Try lossy quantization first (biggest win for photo-PNGs)
         if settings.pngQuantizationEnabled {
@@ -348,9 +349,9 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     /// - Parameter url: The URL of the WebP image
     /// - Returns: The optimized WebP data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizeWebPData(at url: URL) async throws -> Data {
+    private func optimizeWebPData(at url: URL, settings: CompressionSettings) async throws -> Data {
         logger.debug("Optimizing WebP: \(url.lastPathComponent)")
-        return try await compressWithCGImageDestination(at: url, type: .webP, errorFactory: TrimrPixError.webpCompressionFailed)
+        return try await compressWithCGImageDestination(at: url, type: .webP, settings: settings, errorFactory: TrimrPixError.webpCompressionFailed)
     }
     
     /// Optimizes AVIF image data using CGImageDestination
@@ -358,22 +359,22 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     /// - Parameter url: The URL of the AVIF image
     /// - Returns: The optimized AVIF data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizeAVIFData(at url: URL) async throws -> Data {
+    private func optimizeAVIFData(at url: URL, settings: CompressionSettings) async throws -> Data {
         logger.debug("Optimizing AVIF: \(url.lastPathComponent)")
         guard let avifType = UTType("public.avif") else {
             logger.warning("AVIF UTType not available, returning original data")
             return try Data(contentsOf: url)
         }
-        return try await compressWithCGImageDestination(at: url, type: avifType, errorFactory: TrimrPixError.avifCompressionFailed)
+        return try await compressWithCGImageDestination(at: url, type: avifType, settings: settings, errorFactory: TrimrPixError.avifCompressionFailed)
     }
 
     /// Optimizes HEIC image data using CGImageDestination
     /// - Parameter url: The URL of the HEIC image
     /// - Returns: The optimized HEIC data
     /// - Throws: TrimrPixError if optimization fails
-    private func optimizeHEICData(at url: URL) async throws -> Data {
+    private func optimizeHEICData(at url: URL, settings: CompressionSettings) async throws -> Data {
         logger.debug("Optimizing HEIC: \(url.lastPathComponent)")
-        return try await compressWithCGImageDestination(at: url, type: .heic, errorFactory: TrimrPixError.heicCompressionFailed)
+        return try await compressWithCGImageDestination(at: url, type: .heic, settings: settings, errorFactory: TrimrPixError.heicCompressionFailed)
     }
     
     // MARK: - CGImageDestination Compression
@@ -390,10 +391,11 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     private func compressWithCGImageDestination(
         at url: URL,
         type: UTType,
+        settings: CompressionSettings,
         extraOptions: [CFString: Any] = [:],
         errorFactory: (URL) -> TrimrPixError
     ) async throws -> Data {
-        let cgImage = try loadImage(at: url, errorFactory: errorFactory)
+        let cgImage = try loadImage(at: url, settings: settings, errorFactory: errorFactory)
 
         let outputData = NSMutableData()
         guard let destination = CGImageDestinationCreateWithData(
@@ -436,7 +438,7 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
     ///   - errorFactory: A closure that creates the appropriate TrimrPixError
     /// - Returns: A CGImage ready for compression
     /// - Throws: TrimrPixError if loading fails
-    private func loadImage(at url: URL, errorFactory: (URL) -> TrimrPixError) throws -> CGImage {
+    private func loadImage(at url: URL, settings: CompressionSettings, errorFactory: (URL) -> TrimrPixError) throws -> CGImage {
         guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
             let error = TrimrPixError.imageLoadFailed(url: url, underlyingError: nil)
             logger.error("Failed to create image source: \(error.technicalDescription)")

--- a/TrimrPix/Services/CompressionService.swift
+++ b/TrimrPix/Services/CompressionService.swift
@@ -12,8 +12,10 @@ import ImageIO
 import UniformTypeIdentifiers
 
 /// Service responsible for image compression and optimization
-/// Implements CompressionServiceProtocol for dependency injection and testing
-final class CompressionService: CompressionServiceProtocol {
+/// Implements CompressionServiceProtocol for dependency injection and testing.
+/// `@unchecked Sendable`: all stored dependencies are immutable `let`s; the service
+/// holds no mutable state, so it is safe to share across concurrency domains.
+final class CompressionService: CompressionServiceProtocol, @unchecked Sendable {
     
     // MARK: - Dependencies
     

--- a/TrimrPix/Services/Logger.swift
+++ b/TrimrPix/Services/Logger.swift
@@ -24,8 +24,9 @@ enum LogLevel: String, CaseIterable {
 }
 
 /// Protocol defining the logging interface
-/// Enables dependency injection and testing by allowing mock implementations
-protocol LoggerProtocol {
+/// Enables dependency injection and testing by allowing mock implementations.
+/// `Sendable` so a logger can be used from background work (e.g. watch-folder processing).
+protocol LoggerProtocol: Sendable {
     /// Logs a message with the specified severity level
     /// - Parameters:
     ///   - level: The severity level of the log message
@@ -88,7 +89,7 @@ extension LoggerProtocol {
 
 /// Centralized logging service implementation using OSLog
 /// Provides structured logging with different severity levels using Apple's unified logging system
-final class Logger: LoggerProtocol {
+final class Logger: LoggerProtocol, @unchecked Sendable {
     /// Shared singleton instance
     static let shared = Logger()
     

--- a/TrimrPix/Services/MetricsService.swift
+++ b/TrimrPix/Services/MetricsService.swift
@@ -12,7 +12,10 @@ import MetricKit
 /// Crash reports, hang diagnostics, and performance metrics are delivered
 /// through Apple's anonymised pipeline — no user-identifiable data leaves
 /// the device, and no third-party services are involved.
-final class MetricsService: NSObject, MXMetricManagerSubscriber {
+///
+/// `@unchecked Sendable`: holds no mutable state (only an immutable `let logger`),
+/// so the `shared` singleton is safe to reference from any context.
+final class MetricsService: NSObject, MXMetricManagerSubscriber, @unchecked Sendable {
 
     static let shared = MetricsService()
     private let logger: any LoggerProtocol

--- a/TrimrPix/Services/Protocols.swift
+++ b/TrimrPix/Services/Protocols.swift
@@ -11,8 +11,10 @@ import AppKit
 // MARK: - Compression Service Protocol
 
 /// Protocol defining the interface for image compression operations
-/// Enables dependency injection and testing
-protocol CompressionServiceProtocol {
+/// Enables dependency injection and testing.
+/// `Sendable` so a compression service can be safely shared with the background
+/// file-processing work in `WatchFolderService`.
+protocol CompressionServiceProtocol: Sendable {
     /// Optimizes an image at the given URL
     /// - Parameter url: The URL of the image to optimize
     /// - Returns: The URL of the optimized image, or nil if optimization failed
@@ -22,7 +24,11 @@ protocol CompressionServiceProtocol {
 
 // MARK: - Watch Folder Service Protocol
 
-/// Protocol defining the interface for file system monitoring
+/// Protocol defining the interface for file system monitoring.
+/// `@MainActor`-isolated: the service owns mutable state (watch status, processed
+/// files) that is only ever touched from the main actor; background file I/O is
+/// dispatched internally with Sendable values only.
+@MainActor
 protocol WatchFolderServiceProtocol {
     /// Starts monitoring a folder for new images
     /// - Parameter path: The folder path to monitor

--- a/TrimrPix/Services/Protocols.swift
+++ b/TrimrPix/Services/Protocols.swift
@@ -16,10 +16,13 @@ import AppKit
 /// file-processing work in `WatchFolderService`.
 protocol CompressionServiceProtocol: Sendable {
     /// Optimizes an image at the given URL
-    /// - Parameter url: The URL of the image to optimize
-    /// - Returns: The URL of the optimized image, or nil if optimization failed
+    /// - Parameters:
+    ///   - url: The URL of the image to optimize
+    ///   - settings: A Sendable snapshot of the settings to use for this compression.
+    ///     Pass `someSettings.compressionSnapshot`, captured on the main actor.
+    /// - Returns: The URL of the optimized image
     /// - Throws: TrimrPixError if optimization fails
-    func optimizeImage(at url: URL) async throws -> URL
+    func optimizeImage(at url: URL, settings: CompressionSettings) async throws -> URL
 }
 
 // MARK: - Watch Folder Service Protocol
@@ -84,7 +87,10 @@ protocol ImageRepositoryProtocol {
 
 // MARK: - Settings Protocol
 
-/// Protocol for application settings management
+/// Protocol for application settings management.
+/// `@MainActor`-isolated: settings are owned by the UI and only mutated/read on the
+/// main actor. Background work takes an immutable `CompressionSettings` snapshot instead.
+@MainActor
 protocol SettingsProtocol: ObservableObject {
     var compressionQuality: Double { get set }
     var compressionPreset: CompressionPreset { get set }
@@ -104,5 +110,32 @@ protocol SettingsProtocol: ObservableObject {
     func setWatchFolder(url: URL) throws
     func getWatchFolderURL() -> URL?
     func incrementOptimizationRuns() -> Int
+}
+
+extension SettingsProtocol {
+    /// An immutable, `Sendable` snapshot of the settings a single compression needs.
+    /// Capture this on the main actor, then hand it to background compression work so
+    /// `CompressionService` never reads mutable settings state off the main thread.
+    var compressionSnapshot: CompressionSettings {
+        CompressionSettings(
+            compressionQuality: compressionQuality,
+            pngQuantizationEnabled: pngQuantizationEnabled,
+            resizeEnabled: resizeEnabled,
+            maxDimension: maxDimension,
+            overwriteOriginal: overwriteOriginal,
+            autoSave: autoSave
+        )
+    }
+}
+
+/// Immutable, `Sendable` snapshot of the settings required to perform one compression.
+/// Decouples the background compression pipeline from the main-actor-isolated `Settings`.
+struct CompressionSettings: Sendable {
+    let compressionQuality: Double
+    let pngQuantizationEnabled: Bool
+    let resizeEnabled: Bool
+    let maxDimension: Int
+    let overwriteOriginal: Bool
+    let autoSave: Bool
 }
 

--- a/TrimrPix/Services/WatchFolderService.swift
+++ b/TrimrPix/Services/WatchFolderService.swift
@@ -197,6 +197,7 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
         let path = watchedPath
         let delaySeconds = settings.watchFolderDelay
         let extensions = supportedExtensions
+        let compressionSettings = settings.compressionSnapshot
         let compressionService = self.compressionService
         let logger = self.logger
 
@@ -237,6 +238,7 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
                 await WatchFolderService.processImageFile(
                     at: fullPath,
                     delaySeconds: delaySeconds,
+                    settings: compressionSettings,
                     compressionService: compressionService,
                     logger: logger
                 )
@@ -257,6 +259,7 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
     nonisolated private static func processImageFile(
         at url: URL,
         delaySeconds: Double,
+        settings: CompressionSettings,
         compressionService: any CompressionServiceProtocol,
         logger: any LoggerProtocol
     ) async {
@@ -303,7 +306,7 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
 
         // Optimize the image.
         do {
-            let optimizedURL = try await compressionService.optimizeImage(at: url)
+            let optimizedURL = try await compressionService.optimizeImage(at: url, settings: settings)
             logger.info("Successfully optimized image from watch folder: \(optimizedURL.lastPathComponent)")
         } catch let error as TrimrPixError {
             logger.error("Failed to optimize image from watch folder: \(error.technicalDescription)")

--- a/TrimrPix/Services/WatchFolderService.swift
+++ b/TrimrPix/Services/WatchFolderService.swift
@@ -9,28 +9,41 @@ import Foundation
 import AppKit
 import UniformTypeIdentifiers
 
-/// Service responsible for monitoring folders for new images
-/// Implements WatchFolderServiceProtocol for dependency injection and testing
+/// Service responsible for monitoring folders for new images.
+///
+/// Implements `WatchFolderServiceProtocol` for dependency injection and testing.
+///
+/// Concurrency model: the service is `@MainActor`-isolated, so all of its mutable
+/// state (`isWatching`, `watchedPath`, `processedFiles`, the dispatch source and the
+/// debounce/scan tasks) lives on the main actor and is free of data races. The
+/// `DispatchSource` event handler runs on a background queue and hops back to the
+/// main actor. The only blocking work — directory scanning and image optimization —
+/// runs in a detached task that captures Sendable values exclusively.
+@MainActor
 final class WatchFolderService: NSObject, WatchFolderServiceProtocol, ObservableObject {
-    
+
     // MARK: - Published Properties
-    
+
     @Published var isWatching: Bool = false
     @Published var watchedPath: String = ""
-    
+
     // MARK: - Private Properties
-    
+
     private var fileSystemWatcher: DispatchSourceFileSystemObject?
     private let fileManager: any FileManagerProtocol
     private let compressionService: any CompressionServiceProtocol
     private let settings: any SettingsProtocol
     private let logger: any LoggerProtocol
     private let supportedExtensions = ["jpg", "jpeg", "png", "gif", "webp", "avif", "heic", "heif"]
-    private var debounceWorkItem: DispatchWorkItem?
+    private var debounceTask: Task<Void, Never>?
+    private var scanTask: Task<Void, Never>?
     private var processedFiles: Set<String> = [] // Track processed files to avoid re-processing
-    
+
+    private static let debounceNanoseconds: UInt64 = 1_000_000_000 // 1s
+    private static let maxProcessedFiles = 1000
+
     // MARK: - Initialization
-    
+
     /// Initializes the watch folder service with dependencies
     /// - Parameters:
     ///   - fileManager: File manager protocol instance (defaults to FileManager.default)
@@ -49,204 +62,218 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
         self.logger = logger
         super.init()
     }
-    
+
     // MARK: - Public Methods
-    
+
     /// Starts monitoring a folder for new images
     /// - Parameter path: The folder path to monitor
     /// - Throws: TrimrPixError if monitoring setup fails
     func startWatching(path: String) throws {
         logger.info("Attempting to start watching folder: \(path)")
-        
+
         // Validate path
         guard !path.isEmpty else {
             let error = TrimrPixError.invalidFilePath(path)
             logger.error("Invalid watch path (empty): \(error.technicalDescription)")
             throw error
         }
-        
+
         guard fileManager.fileExists(atPath: path) else {
             let error = TrimrPixError.watchFolderNotFound(path)
             logger.error("Watch folder not found: \(error.technicalDescription)")
             throw error
         }
-        
+
         // Stop any existing watch
         stopWatching()
-        
+
         // Open file descriptor for watching
         let url = URL(fileURLWithPath: path)
         let fileDescriptor = open(url.path, O_EVTONLY)
-        
+
         guard fileDescriptor != -1 else {
             let error = TrimrPixError.watchFolderSetupFailed(path, underlyingError: nil)
             logger.error("Failed to open watch path: \(error.technicalDescription)")
             throw error
         }
-        
+
         // Create file system watcher
-        fileSystemWatcher = DispatchSource.makeFileSystemObjectSource(
+        let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fileDescriptor,
             eventMask: [.write, .delete, .rename],
             queue: DispatchQueue.global(qos: .background)
         )
-        
-        fileSystemWatcher?.setEventHandler { [weak self] in
-            self?.handleFileSystemEvent()
+
+        // The handler fires on a background queue; hop to the main actor to touch state.
+        source.setEventHandler { [weak self] in
+            Task { @MainActor in
+                self?.handleFileSystemEvent()
+            }
         }
-        
-        fileSystemWatcher?.setCancelHandler {
+
+        source.setCancelHandler {
             close(fileDescriptor)
         }
-        
-        fileSystemWatcher?.resume()
-        
-        // Update published properties
-        DispatchQueue.main.async {
-            self.isWatching = true
-            self.watchedPath = path
-        }
-        
+
+        fileSystemWatcher = source
+        source.resume()
+
+        isWatching = true
+        watchedPath = path
+
         logger.info("Successfully started watching folder: \(path)")
     }
-    
+
     /// Stops monitoring the current folder
     func stopWatching() {
         guard isWatching else { return }
-        
+
         logger.info("Stopping watch folder monitoring")
-        
-        // Cancel debounce work item
-        debounceWorkItem?.cancel()
-        debounceWorkItem = nil
-        
+
+        // Cancel pending debounce / scan work
+        debounceTask?.cancel()
+        debounceTask = nil
+        scanTask?.cancel()
+        scanTask = nil
+
         // Cancel file system watcher
         fileSystemWatcher?.cancel()
         fileSystemWatcher = nil
-        
-        // Update published properties
-        DispatchQueue.main.async {
-            self.isWatching = false
-            self.watchedPath = ""
-        }
-        
-        logger.info("Stopped watching folder")
-        
+
+        isWatching = false
+        watchedPath = ""
+
         // Clear processed files tracking
-        Task { @MainActor in
-            self.processedFiles.removeAll()
-        }
+        processedFiles.removeAll()
+
+        logger.info("Stopped watching folder")
     }
-    
+
     // MARK: - Private Methods
-    
+
     /// Checks if a file has already been processed
     /// - Parameter fileKey: The file path to check
     /// - Returns: True if the file has been processed
-    @MainActor
     private func isFileProcessed(_ fileKey: String) -> Bool {
         return processedFiles.contains(fileKey)
     }
-    
+
     /// Marks a file as processed
     /// - Parameter fileKey: The file path to mark
-    @MainActor
     private func markFileAsProcessed(_ fileKey: String) {
         processedFiles.insert(fileKey)
-        
-        // Limit the size of processed files set to prevent memory growth
-        // Keep only the most recent 1000 entries
-        if processedFiles.count > 1000 {
-            let toRemove = processedFiles.prefix(processedFiles.count - 1000)
+
+        // Limit the size of the processed files set to prevent memory growth.
+        // Keep only the most recent entries.
+        if processedFiles.count > Self.maxProcessedFiles {
+            let toRemove = processedFiles.prefix(processedFiles.count - Self.maxProcessedFiles)
             processedFiles.subtract(toRemove)
         }
     }
-    
+
     /// Handles file system events with debouncing
     private func handleFileSystemEvent() {
-        // Cancel previous debounce work item
-        debounceWorkItem?.cancel()
-        
-        // Create new debounce work item
-        let workItem = DispatchWorkItem { [weak self] in
+        // Restart the debounce window on every event.
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.debounceNanoseconds)
+            guard !Task.isCancelled else { return }
             self?.processNewFiles()
         }
-        
-        debounceWorkItem = workItem
-        
-        // Schedule work item with delay (1 second debounce)
-        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 1.0, execute: workItem)
     }
-    
-    /// Processes new files in the watched folder
-    @objc private func processNewFiles() {
+
+    /// Processes new files in the watched folder.
+    ///
+    /// Snapshots the values needed for the scan on the main actor, then performs the
+    /// blocking directory read and image optimization in a detached task that captures
+    /// only Sendable values.
+    private func processNewFiles() {
         guard !watchedPath.isEmpty else {
             logger.warning("Process new files called but watched path is empty")
             return
         }
-        
-        logger.debug("Processing new files in watched folder: \(watchedPath)")
-        
-        Task.detached { [weak self] in
-            guard let self = self else { return }
-            
-            // Copy settings values on main actor before background work to avoid data races
-            let delaySeconds = await MainActor.run {
-                self.settings.watchFolderDelay
-            }
-            
+
+        // Snapshot Sendable values on the main actor before doing background work.
+        let path = watchedPath
+        let delaySeconds = settings.watchFolderDelay
+        let extensions = supportedExtensions
+        let compressionService = self.compressionService
+        let logger = self.logger
+
+        logger.debug("Processing new files in watched folder: \(path)")
+
+        scanTask = Task.detached { [weak self] in
+            let contents: [String]
             do {
-                let contents = try self.fileManager.contentsOfDirectory(atPath: self.watchedPath)
-                let imageFiles = contents.filter { file in
-                    let fileExtension = (file as NSString).pathExtension.lowercased()
-                    // Filter out output files (e.g., *-optimized.*) to prevent re-optimization loop
-                    let filename = (file as NSString).deletingPathExtension
-                    let isOutputFile = filename.contains("-optimized")
-                    
-                    return self.supportedExtensions.contains(fileExtension) && !isOutputFile
-                }
-                
-                logger.debug("Found \(imageFiles.count) image file(s) in watched folder (excluding output files)")
-                
-                for imageFile in imageFiles {
-                    let fullPath = URL(fileURLWithPath: self.watchedPath).appendingPathComponent(imageFile)
-                    let fileKey = fullPath.path
-                    
-                    // Skip if already processed
-                    if await self.isFileProcessed(fileKey) {
-                        logger.debug("Skipping already processed file: \(imageFile)")
-                        continue
-                    }
-                    
-                    await self.processImageFile(at: fullPath, delaySeconds: delaySeconds)
-                    await self.markFileAsProcessed(fileKey)
-                }
+                contents = try FileManager.default.contentsOfDirectory(atPath: path)
             } catch {
-                let trimmedError = TrimrPixError.watchFolderSetupFailed(self.watchedPath, underlyingError: error)
-                self.logger.error("Error reading watch folder contents: \(trimmedError.technicalDescription)")
+                let trimmedError = TrimrPixError.watchFolderSetupFailed(path, underlyingError: error)
+                logger.error("Error reading watch folder contents: \(trimmedError.technicalDescription)")
+                return
+            }
+
+            let imageFiles = contents.filter { file in
+                let fileExtension = (file as NSString).pathExtension.lowercased()
+                // Filter out output files (e.g., *-optimized.*) to prevent a re-optimization loop.
+                let filename = (file as NSString).deletingPathExtension
+                let isOutputFile = filename.contains("-optimized")
+                return extensions.contains(fileExtension) && !isOutputFile
+            }
+
+            logger.debug("Found \(imageFiles.count) image file(s) in watched folder (excluding output files)")
+
+            for imageFile in imageFiles {
+                if Task.isCancelled { return }
+
+                let fullPath = URL(fileURLWithPath: path).appendingPathComponent(imageFile)
+                let fileKey = fullPath.path
+
+                // Skip if already processed (state lives on the main actor).
+                if await self?.isFileProcessed(fileKey) == true {
+                    logger.debug("Skipping already processed file: \(imageFile)")
+                    continue
+                }
+
+                await WatchFolderService.processImageFile(
+                    at: fullPath,
+                    delaySeconds: delaySeconds,
+                    compressionService: compressionService,
+                    logger: logger
+                )
+                await self?.markFileAsProcessed(fileKey)
             }
         }
     }
-    
-    /// Processes a single image file from the watched folder
+
+    /// Processes a single image file from the watched folder.
+    ///
+    /// `nonisolated` so it runs off the main actor; it takes its collaborators as
+    /// Sendable parameters rather than reading isolated instance state.
     /// - Parameters:
     ///   - url: The URL of the image file to process
-    ///   - delaySeconds: The delay in seconds to wait for file stability (copied from settings to avoid data race)
-    private func processImageFile(at url: URL, delaySeconds: Double) async {
+    ///   - delaySeconds: The delay in seconds to wait for file stability
+    ///   - compressionService: The compression service to optimize with
+    ///   - logger: The logger to report progress/errors with
+    nonisolated private static func processImageFile(
+        at url: URL,
+        delaySeconds: Double,
+        compressionService: any CompressionServiceProtocol,
+        logger: any LoggerProtocol
+    ) async {
         logger.debug("Processing image file: \(url.lastPathComponent)")
-        
-        // Check if file is still being written to (size changes)
+
+        // Check if the file is still being written to (size changes).
         let initialSize: Int64
         do {
-            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
             initialSize = attributes[.size] as? Int64 ?? 0
         } catch {
             let error = TrimrPixError.fileSizeReadError(url, underlyingError: error)
             logger.warning("Could not read initial file size: \(error.technicalDescription)")
             return
         }
-        
-        // Wait for file to stabilize (using copied delay value to avoid data race)
+
+        // Wait for the file to stabilize.
         let delayNanoseconds = UInt64(delaySeconds * 1_000_000_000)
         do {
             try await Task.sleep(nanoseconds: delayNanoseconds)
@@ -254,27 +281,27 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
             logger.warning("Task sleep interrupted")
             return
         }
-        
-        // Check final size
+
+        // Check final size.
         let finalSize: Int64
         do {
-            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
             finalSize = attributes[.size] as? Int64 ?? 0
         } catch {
             let error = TrimrPixError.fileSizeReadError(url, underlyingError: error)
             logger.warning("Could not read final file size: \(error.technicalDescription)")
             return
         }
-        
-        // Only process if file size is stable
+
+        // Only process if the file size is stable.
         guard initialSize == finalSize, initialSize > 0 else {
             logger.debug("File size not stable for: \(url.lastPathComponent), skipping")
             return
         }
-        
+
         logger.info("Processing new image from watch folder: \(url.lastPathComponent)")
-        
-        // Optimize the image
+
+        // Optimize the image.
         do {
             let optimizedURL = try await compressionService.optimizeImage(at: url)
             logger.info("Successfully optimized image from watch folder: \(optimizedURL.lastPathComponent)")
@@ -285,10 +312,16 @@ final class WatchFolderService: NSObject, WatchFolderServiceProtocol, Observable
             logger.error("Failed to optimize image from watch folder: \(trimmedError.technicalDescription)")
         }
     }
-    
+
     // MARK: - Deinitialization
-    
+
     deinit {
-        stopWatching()
+        // Best-effort teardown. The owning view model calls stopWatching() explicitly;
+        // here we only cancel the GCD source and pending tasks (all safe to cancel from
+        // any thread) so the file descriptor is released if the service is torn down
+        // without an explicit stop.
+        debounceTask?.cancel()
+        scanTask?.cancel()
+        fileSystemWatcher?.cancel()
     }
 }

--- a/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
+++ b/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
@@ -10,16 +10,6 @@ import SwiftUI
 import StoreKit
 import UniformTypeIdentifiers
 
-private extension ImageItem {
-    static var placeholder: ImageItem {
-        // Create a minimal placeholder that won't be used; values won't be accessed
-        // Use a temporary file URL as a dummy
-        let tempURL = URL(fileURLWithPath: "/dev/null")
-        // Force-try is acceptable here because it's only used when index is missing and won't be accessed
-        return try! ImageItem(url: tempURL)
-    }
-}
-
 /// ViewModel responsible for managing image optimization operations
 /// Coordinates between UI, compression service, and watch folder service
 @MainActor
@@ -51,6 +41,11 @@ final class ImageOptimizationViewModel: ObservableObject {
     /// Tracks security-scoped resource access for dropped files
     /// Maps image ID to whether access was granted
     private var securityScopedAccess: [UUID: Bool] = [:]
+
+    /// The watch-folder URL we started security-scoped access on, if any.
+    /// Kept so `stopWatchFolder()` can balance the `startAccessingSecurityScopedResource()`
+    /// call and avoid leaking a security-scope reference on each start.
+    private var watchFolderScopedURL: URL?
     
     // MARK: - Initialization
     
@@ -246,81 +241,73 @@ final class ImageOptimizationViewModel: ObservableObject {
     /// Optimizes a single image at the specified index
     /// - Parameter index: The index of the image to optimize
     func optimizeImage(at index: Int) async {
-        guard index < images.count else {
+        guard images.indices.contains(index) else {
             logger.warning("Optimize image called with invalid index: \(index)")
             return
         }
-        
-        let imageItem: ImageItem = await MainActor.run { self.images[index] }
-        logger.info("Starting optimization for: \(imageItem.filename)")
-        
-        // Set optimizing state on main actor
-        await MainActor.run {
-            self.images[index].isOptimizing = true
-        }
-        
-        // Optimize the image in background
-        do {
-            let optimizedURL = try await compressionService.optimizeImage(at: imageItem.url)
-            
-            // Get optimized file size
-            do {
-                let attributes = try FileManager.default.attributesOfItem(atPath: optimizedURL.path)
-                let optimizedSize = attributes[.size] as? Int64 ?? 0
-                
-                // Update image item on main actor
-                await MainActor.run {
-                    self.images[index].optimizedSize = optimizedSize
-                    self.images[index].isOptimized = true
-                    self.images[index].isOptimizing = false
-                }
-                
-                let savings: Int = await MainActor.run { self.images[index].savingsPercentage }
-                self.logger.info("Successfully optimized: \(imageItem.filename) - \(savings)% reduction")
-                
-            } catch {
-                let error = TrimrPixError.fileSizeReadError(optimizedURL, underlyingError: error)
-                logger.error("Error reading optimized file size: \(error.technicalDescription)")
-                await MainActor.run {
-                    self.images[index].isOptimizing = false
-                    self.showError(message: error.errorDescription ?? "Kunne ikke læse filstørrelse")
-                }
-            }
-            
-        } catch let error as TrimrPixError {
-            logger.error("Optimization failed: \(error.technicalDescription)")
-            await MainActor.run {
-                self.images[index].isOptimizing = false
-                self.showError(message: error.errorDescription ?? "Kunne ikke optimere billede")
-            }
-        } catch {
-            let trimmedError = TrimrPixError.compressionFailed(url: imageItem.url, underlyingError: error)
-            logger.error("Optimization failed: \(trimmedError.technicalDescription)")
-            await MainActor.run {
-                self.images[index].isOptimizing = false
-                self.showError(message: trimmedError.errorDescription ?? "Kunne ikke optimere billede")
-            }
-        }
+        // Delegate to the ID-based implementation so the operation stays correct
+        // even if the list is mutated while compression is running.
+        await optimizeImage(withID: images[index].id)
     }
-    
-    /// Optimizes a single image identified by its ID
+
+    /// Optimizes a single image identified by its ID.
+    ///
+    /// The image's current index is re-resolved from its ID after every suspension
+    /// point. If the image is removed or reordered while compression runs, the update
+    /// is skipped gracefully instead of crashing or mutating the wrong item.
     /// - Parameter id: The ID of the image to optimize
     private func optimizeImage(withID id: UUID) async {
-        // Resolve the current index for this ID on the main actor
-        let result = await MainActor.run {
-            if let idx = self.images.firstIndex(where: { $0.id == id }) {
-                return (idx, self.images[idx])
-            } else {
-                return (-1, ImageItem.placeholder)
-            }
-        }
-        
-        guard result.0 >= 0 else {
+        guard let imageItem = images.first(where: { $0.id == id }) else {
             logger.warning("Optimize image called with missing ID: \(id)")
             return
         }
-        
-        await optimizeImage(at: result.0)
+        logger.info("Starting optimization for: \(imageItem.filename)")
+
+        if let idx = images.firstIndex(where: { $0.id == id }) {
+            images[idx].isOptimizing = true
+        }
+
+        do {
+            let optimizedURL = try await compressionService.optimizeImage(at: imageItem.url)
+
+            do {
+                let attributes = try FileManager.default.attributesOfItem(atPath: optimizedURL.path)
+                let optimizedSize = attributes[.size] as? Int64 ?? 0
+
+                // Re-resolve the index after the await — the list may have changed.
+                guard let idx = images.firstIndex(where: { $0.id == id }) else {
+                    logger.debug("Image removed during optimization, skipping update: \(imageItem.filename)")
+                    return
+                }
+                images[idx].optimizedSize = optimizedSize
+                images[idx].isOptimized = true
+                images[idx].isOptimizing = false
+                logger.info("Successfully optimized: \(imageItem.filename) - \(images[idx].savingsPercentage)% reduction")
+
+            } catch {
+                let error = TrimrPixError.fileSizeReadError(optimizedURL, underlyingError: error)
+                logger.error("Error reading optimized file size: \(error.technicalDescription)")
+                clearOptimizing(id: id)
+                showError(message: error.errorDescription ?? "Kunne ikke læse filstørrelse")
+            }
+
+        } catch let error as TrimrPixError {
+            logger.error("Optimization failed: \(error.technicalDescription)")
+            clearOptimizing(id: id)
+            showError(message: error.errorDescription ?? "Kunne ikke optimere billede")
+        } catch {
+            let trimmedError = TrimrPixError.compressionFailed(url: imageItem.url, underlyingError: error)
+            logger.error("Optimization failed: \(trimmedError.technicalDescription)")
+            clearOptimizing(id: id)
+            showError(message: trimmedError.errorDescription ?? "Kunne ikke optimere billede")
+        }
+    }
+
+    /// Clears the `isOptimizing` flag for the image with the given ID, if it still exists.
+    private func clearOptimizing(id: UUID) {
+        if let idx = images.firstIndex(where: { $0.id == id }) {
+            images[idx].isOptimizing = false
+        }
     }
     
     /// Starts watch folder monitoring if enabled in settings
@@ -333,8 +320,11 @@ final class ImageOptimizationViewModel: ObservableObject {
         // Try to get watch folder URL from bookmark first
         var watchFolderPath: String
         if let bookmarkURL = settings.getWatchFolderURL() {
-            // Start accessing security-scoped resource from bookmark
-            _ = bookmarkURL.startAccessingSecurityScopedResource()
+            // Start accessing security-scoped resource from bookmark.
+            // Track the URL so stopWatchFolder() can balance this call (avoids leaking a scope reference).
+            if bookmarkURL.startAccessingSecurityScopedResource() {
+                watchFolderScopedURL = bookmarkURL
+            }
             watchFolderPath = bookmarkURL.path
             logger.debug("Using watch folder from bookmark: \(watchFolderPath)")
         } else if !settings.watchFolderPath.isEmpty {
@@ -373,11 +363,20 @@ final class ImageOptimizationViewModel: ObservableObject {
     
     /// Stops watch folder monitoring
     func stopWatchFolder() {
+        // Balance the security-scoped access started in startWatchFolder().
+        // Done unconditionally (before the isWatching guard) so a scope acquired
+        // during a start that later failed to begin watching is still released.
+        if let scopedURL = watchFolderScopedURL {
+            scopedURL.stopAccessingSecurityScopedResource()
+            watchFolderScopedURL = nil
+            logger.debug("Stopped security-scoped access for watch folder")
+        }
+
         guard watchFolderService.isWatching else {
             logger.debug("Watch folder not active, skipping stop")
             return
         }
-        
+
         watchFolderService.stopWatching()
         logger.info("Watch folder stopped")
     }

--- a/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
+++ b/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
@@ -263,12 +263,15 @@ final class ImageOptimizationViewModel: ObservableObject {
         }
         logger.info("Starting optimization for: \(imageItem.filename)")
 
+        // Snapshot settings on the main actor before crossing into background work.
+        let settingsSnapshot = settings.compressionSnapshot
+
         if let idx = images.firstIndex(where: { $0.id == id }) {
             images[idx].isOptimizing = true
         }
 
         do {
-            let optimizedURL = try await compressionService.optimizeImage(at: imageItem.url)
+            let optimizedURL = try await compressionService.optimizeImage(at: imageItem.url, settings: settingsSnapshot)
 
             do {
                 let attributes = try FileManager.default.attributesOfItem(atPath: optimizedURL.path)

--- a/TrimrPixTests/CompressionServiceTests.swift
+++ b/TrimrPixTests/CompressionServiceTests.swift
@@ -19,6 +19,7 @@ import Combine
 
 /// In-memory settings stub. Avoids touching UserDefaults / Settings.shared
 /// so tests don't pollute the user's real preferences.
+@MainActor
 final class StubSettings: SettingsProtocol {
     @Published var compressionQuality: Double = 0.8
     @Published var compressionPreset: CompressionPreset = .medium
@@ -98,16 +99,18 @@ final class TempDir {
 // MARK: - Tests
 
 @Suite("CompressionService")
+@MainActor
 struct CompressionServiceTests {
 
     // MARK: Error paths
 
     @Test func throwsFileNotFoundForMissingFile() async throws {
-        let service = CompressionService(settings: StubSettings())
+        let service = CompressionService()
+        let settings = StubSettings().compressionSnapshot
         let missing = URL(fileURLWithPath: "/tmp/trimrpix-nonexistent-\(UUID().uuidString).jpg")
 
         await #expect(throws: TrimrPixError.self) {
-            _ = try await service.optimizeImage(at: missing)
+            _ = try await service.optimizeImage(at: missing, settings: settings)
         }
     }
 
@@ -116,10 +119,10 @@ struct CompressionServiceTests {
         let bogus = tmp.file("file.xyz")
         try Data("not an image".utf8).write(to: bogus)
 
-        let service = CompressionService(settings: StubSettings())
+        let service = CompressionService()
 
         do {
-            _ = try await service.optimizeImage(at: bogus)
+            _ = try await service.optimizeImage(at: bogus, settings: StubSettings().compressionSnapshot)
             Issue.record("Expected unsupportedImageFormat error")
         } catch let error as TrimrPixError {
             if case .unsupportedImageFormat = error { /* ok */ }
@@ -132,10 +135,10 @@ struct CompressionServiceTests {
         let fake = tmp.file("fake.gif")
         try Data("NOPE_NOT_A_GIF_HEADER".utf8).write(to: fake)
 
-        let service = CompressionService(settings: StubSettings())
+        let service = CompressionService()
 
         do {
-            _ = try await service.optimizeImage(at: fake)
+            _ = try await service.optimizeImage(at: fake, settings: StubSettings().compressionSnapshot)
             Issue.record("Expected error for corrupt GIF")
         } catch let error as TrimrPixError {
             // GIF validation runs the header check, so we expect invalidImageData.
@@ -155,8 +158,8 @@ struct CompressionServiceTests {
         settings.autoSave = true
         settings.overwriteOriginal = false
 
-        let service = CompressionService(settings: settings)
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: settings.compressionSnapshot)
 
         #expect(FileManager.default.fileExists(atPath: output.path))
         #expect(output.lastPathComponent.contains("-optimized"))
@@ -170,8 +173,8 @@ struct CompressionServiceTests {
         let input = tmp.file("graphic.png")
         try TestImage.write(to: input, type: .png)
 
-        let service = CompressionService(settings: StubSettings())
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: StubSettings().compressionSnapshot)
 
         #expect(FileManager.default.fileExists(atPath: output.path))
         #expect(output.pathExtension.lowercased() == "png")
@@ -182,8 +185,8 @@ struct CompressionServiceTests {
         let input = tmp.file("photo.heic")
         try TestImage.write(to: input, type: .heic)
 
-        let service = CompressionService(settings: StubSettings())
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: StubSettings().compressionSnapshot)
 
         #expect(FileManager.default.fileExists(atPath: output.path))
         #expect(output.pathExtension.lowercased() == "heic")
@@ -201,8 +204,8 @@ struct CompressionServiceTests {
         settings.overwriteOriginal = true
         settings.compressionQuality = 0.6 // force smaller output
 
-        let service = CompressionService(settings: settings)
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: settings.compressionSnapshot)
 
         #expect(output.path == input.path)
         let newSize = try Data(contentsOf: input).count
@@ -221,8 +224,8 @@ struct CompressionServiceTests {
         let collision = tmp.file("photo-optimized.jpg")
         try Data("existing".utf8).write(to: collision)
 
-        let service = CompressionService(settings: StubSettings())
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: StubSettings().compressionSnapshot)
 
         #expect(output.path != collision.path)
         #expect(output.lastPathComponent.hasPrefix("photo-optimized"))
@@ -241,8 +244,8 @@ struct CompressionServiceTests {
         settings.resizeEnabled = true
         settings.maxDimension = 256
 
-        let service = CompressionService(settings: settings)
-        let output = try await service.optimizeImage(at: input)
+        let service = CompressionService()
+        let output = try await service.optimizeImage(at: input, settings: settings.compressionSnapshot)
 
         guard let src = CGImageSourceCreateWithURL(output as CFURL, nil),
               let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any],

--- a/TrimrPixTests/TrimrPixTests.swift
+++ b/TrimrPixTests/TrimrPixTests.swift
@@ -87,7 +87,7 @@ struct TrimrPixTests {
     
     // MARK: - Settings Tests
     
-    @Test func testSettingsValidation() async throws {
+    @Test @MainActor func testSettingsValidation() async throws {
         let settings = Settings.shared
         
         // Test compression quality validation
@@ -101,7 +101,7 @@ struct TrimrPixTests {
         #expect(settings.compressionQuality == 0.95)
     }
     
-    @Test func testWatchFolderPathValidation() async throws {
+    @Test @MainActor func testWatchFolderPathValidation() async throws {
         let settings = Settings.shared
         
         // Test with invalid path

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>document.documentElement.classList.add('js');</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-itunes-app" content="app-id=6758639590">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -82,7 +83,7 @@
                     </ul>
                 </div>
                 <div class="hero-visual">
-                    <img src="screenshot-1.png" alt="TrimrPix app window showing image optimization with drag and drop and file size savings" width="1200" height="800" loading="eager" fetchpriority="high" class="hero-screenshot">
+                    <img src="screenshot-1.png" alt="TrimrPix app window showing image optimization with drag and drop and file size savings" width="1800" height="900" loading="eager" fetchpriority="high" class="hero-screenshot">
                 </div>
             </div>
         </section>
@@ -92,9 +93,9 @@
             <div class="container">
                 <h2 class="visually-hidden">TrimrPix in action</h2>
                 <div class="gallery-grid">
-                    <img src="screenshot-1.png" alt="TrimrPix main window – add images and optimize" width="800" height="533" loading="lazy" class="gallery-img reveal">
-                    <img src="screenshot-2.png" alt="TrimrPix – compression settings and batch processing" width="800" height="533" loading="lazy" class="gallery-img reveal">
-                    <img src="screenshot-3.png" alt="TrimrPix – before and after file sizes" width="800" height="533" loading="lazy" class="gallery-img reveal">
+                    <img src="screenshot-1.png" alt="TrimrPix main window – add images and optimize" width="1800" height="900" loading="lazy" class="gallery-img reveal">
+                    <img src="screenshot-2.png" alt="TrimrPix – compression settings and batch processing" width="1000" height="1040" loading="lazy" class="gallery-img reveal">
+                    <img src="screenshot-3.png" alt="TrimrPix – before and after file sizes" width="1892" height="1084" loading="lazy" class="gallery-img reveal">
                 </div>
             </div>
         </section>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -356,7 +356,7 @@ body {
 }
 
 .hero-ios a {
-    color: var(--color-accent);
+    color: var(--color-primary);
     text-decoration: none;
     font-weight: 500;
     transition: opacity 0.2s ease;
@@ -1151,13 +1151,15 @@ body {
 }
 
 /* ---- Scroll reveal animations ---- */
-.reveal {
+/* Only hide for reveal when JS is available — otherwise content (FAQ, tables,
+   feature cards) would be permanently invisible for no-JS users and crawlers. */
+.js .reveal {
     opacity: 0;
     transform: translateY(24px);
     transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
-.reveal.revealed {
+.js .reveal.revealed {
     opacity: 1;
     transform: translateY(0);
 }
@@ -1297,6 +1299,12 @@ body {
 }
 
 /* ---- Accessibility ---- */
+:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 @media (prefers-reduced-motion: reduce) {
     *,
     *::before,
@@ -1307,7 +1315,7 @@ body {
         scroll-behavior: auto !important;
     }
 
-    .reveal {
+    .js .reveal {
         opacity: 1;
         transform: none;
     }


### PR DESCRIPTION
Addresses the highest-priority findings from a code review of the app and marketing site, completes the Swift 6 strict-concurrency migration, and fixes a pre-existing CI break.

## Marketing site (`docs/`) — verified in preview
- **Undefined `--color-accent`** → use `--color-primary` so the hero iOS link renders in all themes.
- **No focus indicator** → added a global `:focus-visible` outline.
- **Wrong image dimensions** → corrected hero + gallery `width`/`height` to true aspect ratios (1800×900, 1000×1040, 1892×1084) to fix CLS.
- **`.reveal` hidden without JS** → gated scroll-reveal behind a `.js` class so FAQ/tables/cards stay visible for no-JS users and crawlers.

## App (`TrimrPix/`)
- **Watch-folder security-scope leak** → `stopWatchFolder()` now releases the scoped URL acquired in `startWatchFolder()`.
- **Image-optimization index race** → `optimizeImage(at:)` is ID-based and re-resolves the index after every `await`; removed redundant `MainActor.run` wrappers and the unused `ImageItem.placeholder`.
- **`WatchFolderService` data races** → isolated to `@MainActor`; DispatchSource handler hops to main; cancellable `Task` debounce; blocking scan/optimize runs in a detached task capturing only Sendable values.
- **Off-main settings race (the real bug)** → introduced a Sendable `CompressionSettings` snapshot; `optimizeImage(at:settings:)` takes it, `CompressionService` no longer holds Settings and is stateless. `Settings`/`SettingsProtocol` are `@MainActor`; `MetricsService` is `@unchecked Sendable`.

## CI
- **CI was red on `main`** (since MetricsService was added): it pinned macos-15 + Xcode 16.2, whose macOS 15.x SDK lacks the MetricKit payload APIs MetricsService uses. Now builds on **macos-26** with the latest Xcode — confirmed green.

## Verification
- Builds clean; all 17 unit tests pass.
- `SWIFT_STRICT_CONCURRENCY=complete` now produces **zero** concurrency/Sendable/actor warnings across the whole module (previously two).
- CI green on macos-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)