### PR TITLE
Adopt Swift 6 language mode

### DIFF
--- a/TrimrPix.xcodeproj/project.pbxproj
+++ b/TrimrPix.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -474,7 +474,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -491,7 +491,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.trimrpix.TrimrPixTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrimrPix.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TrimrPix";
 			};
 			name = Debug;
@@ -509,7 +509,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.trimrpix.TrimrPixTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrimrPix.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TrimrPix";
 			};
 			name = Release;
@@ -525,7 +525,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.trimrpix.TrimrPixUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = TrimrPix;
 			};
 			name = Debug;
@@ -541,7 +541,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.trimrpix.TrimrPixUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = TrimrPix;
 			};
 			name = Release;


### PR DESCRIPTION
Follow-up to the concurrency hardening in #21. Now that the whole module compiles cleanly under `SWIFT_STRICT_CONCURRENCY=complete`, lock it in by switching the language mode.

- `SWIFT_VERSION` 5.0 → 6.0 for the app, `TrimrPixTests` and `TrimrPixUITests` targets.
- Swift 6 mode makes complete data-race checking a compile error, so future concurrency regressions fail the build instead of slipping through as runtime races.

## Verification
- Builds clean across all targets under Swift 6 mode.
- All 17 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)