### PR TITLE
perf: bound batch concurrency, avoid full-file reads for sizing

### DIFF
--- a/TrimrPix/Services/CompressionService.swift
+++ b/TrimrPix/Services/CompressionService.swift
@@ -69,9 +69,17 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
             throw error
         }
         
-        // Read original file size for comparison
-        let originalData = try Data(contentsOf: url)
-        let originalSize = originalData.count
+        // Read original file size for comparison — via attributes, without loading
+        // the whole file into memory (matters for large batches).
+        let originalSize: Int
+        do {
+            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            originalSize = (attributes[.size] as? Int) ?? 0
+        } catch {
+            let trimmedError = TrimrPixError.fileSizeReadError(url, underlyingError: error)
+            logger.error("Failed to read original file size: \(trimmedError.technicalDescription)")
+            throw trimmedError
+        }
 
         // Optimize image based on file type
         var optimizedData: Data
@@ -86,10 +94,12 @@ final class CompressionService: CompressionServiceProtocol, @unchecked Sendable 
             throw trimmedError
         }
 
-        // Guard: if compressed data is larger than original, keep the original
-        if optimizedData.count >= originalSize {
+        // Guard: if compression didn't shrink the file, keep the original bytes.
+        // The original is read lazily here, so the common (successful) path never
+        // loads the whole source file.
+        if originalSize > 0, optimizedData.count >= originalSize {
             logger.info("Compressed size (\(optimizedData.count) bytes) >= original (\(originalSize) bytes), keeping original")
-            optimizedData = originalData
+            optimizedData = try Data(contentsOf: url)
         }
         
         // Generate suggested filename

--- a/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
+++ b/TrimrPix/ViewModels/ImageOptimizationViewModel.swift
@@ -209,14 +209,26 @@ final class ImageOptimizationViewModel: ObservableObject {
             // Capture a stable snapshot of the image IDs to process
             let idsToProcess: [UUID] = await MainActor.run { self.images.map { $0.id } }
             
-            // Perform concurrent processing without touching MainActor-isolated state directly
+            // Process with a bounded number of concurrent optimizations. Each running
+            // optimization decodes a full image into memory, so an unbounded group
+            // would load the entire batch at once — a memory spike on large drops.
+            let maxConcurrent = max(1, min(4, ProcessInfo.processInfo.activeProcessorCount))
             await withTaskGroup(of: Void.self) { group in
-                for id in idsToProcess {
-                    group.addTask { [weak self] in
-                        await self?.optimizeImage(withID: id)
+                var index = 0
+                // Prime the group up to the concurrency limit.
+                while index < maxConcurrent, index < idsToProcess.count {
+                    let id = idsToProcess[index]
+                    group.addTask { [weak self] in await self?.optimizeImage(withID: id) }
+                    index += 1
+                }
+                // As each finishes, start the next one, keeping at most `maxConcurrent` in flight.
+                while await group.next() != nil {
+                    if index < idsToProcess.count {
+                        let id = idsToProcess[index]
+                        group.addTask { [weak self] in await self?.optimizeImage(withID: id) }
+                        index += 1
                     }
                 }
-                await group.waitForAll()
             }
             
             // Update UI state on main actor


### PR DESCRIPTION
From the review backlog. Reduces peak memory during "Optimize All", especially on large image drops.

- **Bounded concurrency** — the optimization TaskGroup now keeps at most `min(4, activeProcessorCount)` jobs in flight instead of launching one per image. Each running job decodes a full image into memory, so an unbounded group loaded the whole batch at once.
- **No full read just to measure size** — `CompressionService` reads the original file size from `FileManager` attributes rather than `Data(contentsOf:)`. The full original is now read lazily and only when compression didn't shrink the file (the existing size-guard fallback).

## Verification
- Builds clean and all 17 tests pass under Swift 6 mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)