### PR TITLE
seo: Remove EXIF Data on Mac landing page (closes #6)

### DIFF
--- a/docs/compress-images-for-web.html
+++ b/docs/compress-images-for-web.html
@@ -132,6 +132,7 @@
                 <ul>
                     <li><a href="image-formats-guide.html">JPEG vs PNG vs WebP vs AVIF vs HEIC: Image Formats Guide</a></li>
                     <li><a href="batch-image-compression.html">Batch Image Compression on Mac</a></li>
+                    <li><a href="remove-exif-data-on-mac.html">How to Remove EXIF Data on Mac</a></li>
                 </ul>
             </nav>
         </div>

--- a/docs/image-formats-guide.html
+++ b/docs/image-formats-guide.html
@@ -212,6 +212,7 @@
                 <ul>
                     <li><a href="compress-images-for-web.html">How to Compress Images for Your Website</a></li>
                     <li><a href="imageoptim-alternative.html">ImageOptim Alternative for Mac</a></li>
+                    <li><a href="remove-exif-data-on-mac.html">How to Remove EXIF Data on Mac</a></li>
                 </ul>
             </nav>
         </div>

--- a/docs/remove-exif-data-on-mac.html
+++ b/docs/remove-exif-data-on-mac.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>document.documentElement.classList.add('js');</script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="apple-itunes-app" content="app-id=6758639590">
+    <title>How to Remove EXIF Data on Mac – TrimrPix | Strip Photo Metadata</title>
+    <meta name="description" content="Remove EXIF, GPS location, and IPTC metadata from photos on your Mac. TrimrPix strips metadata from JPEG, PNG, HEIC, WebP, AVIF & GIF automatically — fully offline.">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
+    <link rel="canonical" href="https://trimrpix.iamjarl.com/remove-exif-data-on-mac.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://trimrpix.iamjarl.com/remove-exif-data-on-mac.html">
+    <meta property="og:title" content="How to Remove EXIF Data on Mac – TrimrPix">
+    <meta property="og:description" content="Strip EXIF, GPS, and IPTC metadata from your photos on Mac — automatically and fully offline.">
+    <meta property="og:image" content="https://trimrpix.iamjarl.com/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="TrimrPix – batch image compression for Mac">
+    <meta property="og:site_name" content="TrimrPix">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="How to Remove EXIF Data on Mac – TrimrPix">
+    <meta name="twitter:description" content="Strip EXIF, GPS, and IPTC metadata from your photos on Mac — automatically and fully offline.">
+    <meta name="twitter:image" content="https://trimrpix.iamjarl.com/og-image.png">
+
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="apple-touch-icon" href="favicon.png">
+    <link rel="stylesheet" href="styles.css">
+    <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="29beb01b-51b6-4992-a500-841c0b87a62b"></script>
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a href="index.html" class="logo"><img src="app-icon.png" alt="" width="32" height="32" class="logo-icon">TrimrPix</a>
+            <nav class="nav" aria-label="Main navigation">
+                <a href="index.html#features">Features</a>
+                <a href="index.html#faq">FAQ</a>
+                <a href="support.html">Support</a>
+                <a href="https://apps.apple.com/app/trimrpix/id6758639590" class="btn btn-primary btn-sm" target="_blank" rel="noopener noreferrer">Get on Mac</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="article-page">
+        <div class="container">
+            <a href="index.html" class="back-link">&larr; Back to TrimrPix</a>
+
+            <div class="article-header">
+                <h1 class="section-title">How to Remove EXIF Data on Mac</h1>
+                <p class="article-meta">Updated June 2026 &middot; by IAMJARL</p>
+            </div>
+
+            <div class="answer-box reveal">
+                <p>To remove EXIF data on a Mac: open TrimrPix, drag in your photos, and optimize. EXIF, GPS location, and IPTC metadata are stripped automatically from every image &mdash; there is no setting to toggle, and everything runs fully offline on your device.</p>
+            </div>
+
+            <div class="prose">
+                <h2>What is EXIF data?</h2>
+                <p>EXIF (Exchangeable Image File Format) is metadata your camera or phone embeds in every photo. It can include the date and time, camera model and settings, and &mdash; most sensitively &mdash; the exact <strong>GPS coordinates</strong> where the photo was taken. Photos also often carry IPTC fields (captions, copyright) and vendor data such as Apple's MakerNote.</p>
+
+                <h2>Why remove it?</h2>
+                <ul>
+                    <li><strong>Privacy:</strong> sharing a photo with intact GPS data can reveal your home, workplace, or a child's school.</li>
+                    <li><strong>Smaller files:</strong> stripping metadata shaves bytes off every image &mdash; useful at scale.</li>
+                    <li><strong>Clean publishing:</strong> remove camera and editing traces before posting online or sending to a client.</li>
+                </ul>
+
+                <h2>What TrimrPix removes</h2>
+                <table class="comparison-table reveal">
+                    <thead>
+                        <tr>
+                            <th>Metadata</th>
+                            <th>Examples</th>
+                            <th>Removed</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>EXIF</td>
+                            <td>Date, camera model, exposure, ISO</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>GPS</td>
+                            <td>Latitude / longitude location</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>IPTC</td>
+                            <td>Caption, copyright, keywords</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>MakerNote</td>
+                            <td>Apple / vendor-specific data</td>
+                            <td>Yes</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>Metadata is stripped from <strong>all supported formats</strong> &mdash; JPEG, PNG, HEIC, WebP, AVIF, and GIF.</p>
+
+                <h2>How to remove EXIF data on Mac</h2>
+                <ol class="step-list">
+                    <li class="reveal">Open TrimrPix on your Mac</li>
+                    <li class="reveal">Drag and drop your photos into the window</li>
+                    <li class="reveal">Click Optimize &mdash; metadata is removed automatically</li>
+                    <li class="reveal">Save the cleaned images wherever you like</li>
+                </ol>
+                <p>That's it. Because removing metadata happens as part of optimization, you also get a smaller file in the same step.</p>
+
+                <h2>Does removing EXIF reduce image quality?</h2>
+                <p>No. Stripping metadata is lossless &mdash; it only deletes the hidden information fields, not a single pixel. TrimrPix does re-encode the image to save space, but at the quality you choose (60&ndash;95%), so there is no visible difference for typical use.</p>
+
+                <h2>Is it private?</h2>
+                <p>Yes. TrimrPix processes everything <strong>on your Mac</strong> &mdash; your photos never leave your device, and the app makes no network requests. See the <a href="privacy.html">privacy policy</a> for details.</p>
+            </div>
+
+            <div class="article-cta reveal">
+                <h2>Try TrimrPix</h2>
+                <p>Remove EXIF and GPS data from your photos in seconds. $1.99 on the Mac App Store.</p>
+                <a href="https://apps.apple.com/app/trimrpix/id6758639590" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Download on the App Store</a>
+            </div>
+
+            <nav class="related-articles" aria-label="Related guides">
+                <h2>Related guides</h2>
+                <ul>
+                    <li><a href="image-formats-guide.html">JPEG vs PNG vs WebP vs AVIF vs HEIC: Image Formats Guide</a></li>
+                    <li><a href="compress-images-for-web.html">How to Compress Images for Your Website</a></li>
+                    <li><a href="imageoptim-alternative.html">The Best ImageOptim Alternative for Mac</a></li>
+                </ul>
+            </nav>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p><a href="index.html" style="color: var(--color-text-inverse); text-decoration: none;">TrimrPix</a> &middot; <a href="https://apps.apple.com/app/trimrpix/id6758639590" target="_blank" rel="noopener noreferrer" style="color: var(--color-text-inverse); text-decoration: none;">Mac App Store</a> &middot; <a href="https://apps.apple.com/us/app/trimrpix/id6761081919" target="_blank" rel="noopener noreferrer" style="color: var(--color-text-inverse); text-decoration: none;">iOS App Store</a> &middot; <a href="support.html" style="color: var(--color-text-inverse); text-decoration: none;">Support</a> &middot; <a href="privacy.html" style="color: var(--color-text-inverse); text-decoration: none;">Privacy</a></p>
+                <p><a href="imageoptim-alternative.html" style="color: var(--color-text-inverse); text-decoration: none;">ImageOptim Alternative</a> &middot; <a href="image-formats-guide.html" style="color: var(--color-text-inverse); text-decoration: none;">Formats Guide</a> &middot; <a href="compress-images-for-web.html" style="color: var(--color-text-inverse); text-decoration: none;">Compress for Web</a> &middot; <a href="batch-image-compression.html" style="color: var(--color-text-inverse); text-decoration: none;">Batch Compression</a> &middot; <a href="remove-exif-data-on-mac.html" style="color: var(--color-text-inverse); text-decoration: none;">Remove EXIF Data</a></p>
+                <p>&copy; 2026 <a href="https://iamjarl.com/" target="_blank" rel="noopener noreferrer" style="color: var(--color-text-inverse); text-decoration: none;">IAMJARL</a>. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://trimrpix.iamjarl.com/" },
+            { "@type": "ListItem", "position": 2, "name": "Remove EXIF Data on Mac", "item": "https://trimrpix.iamjarl.com/remove-exif-data-on-mac.html" }
+        ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "How to Remove EXIF Data on Mac",
+        "description": "Remove EXIF, GPS location, and IPTC metadata from photos on your Mac. TrimrPix strips metadata from all formats automatically, fully offline.",
+        "author": { "@type": "Organization", "name": "IAMJARL", "url": "https://iamjarl.com/" },
+        "publisher": { "@type": "Organization", "name": "IAMJARL", "url": "https://iamjarl.com/" },
+        "datePublished": "2026-06-04",
+        "dateModified": "2026-06-04",
+        "mainEntityOfPage": "https://trimrpix.iamjarl.com/remove-exif-data-on-mac.html",
+        "image": "https://trimrpix.iamjarl.com/screenshot-1.png"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            { "@type": "Question", "name": "How do I remove EXIF data on a Mac?", "acceptedAnswer": { "@type": "Answer", "text": "Open TrimrPix, drag in your photos, and click Optimize. EXIF, GPS, and IPTC metadata are removed automatically from every image, fully offline." } },
+            { "@type": "Question", "name": "Does removing EXIF data reduce image quality?", "acceptedAnswer": { "@type": "Answer", "text": "No. Removing metadata is lossless and does not affect pixels. TrimrPix re-encodes at your chosen quality (60-95%), so there is no visible difference for typical use." } },
+            { "@type": "Question", "name": "Does TrimrPix remove GPS location from photos?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. GPS coordinates are stripped along with EXIF, IPTC, and vendor MakerNote data from JPEG, PNG, HEIC, WebP, AVIF, and GIF files." } }
+        ]
+    }
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var obs = new IntersectionObserver(function(entries) {
+            entries.forEach(function(e) {
+                if (e.isIntersecting) { e.target.classList.add('revealed'); obs.unobserve(e.target); }
+            });
+        }, { threshold: 0.1 });
+        document.querySelectorAll('.reveal').forEach(function(el) { obs.observe(el); });
+    });
+    </script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -64,4 +64,10 @@
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
+    <url>
+        <loc>https://trimrpix.iamjarl.com/remove-exif-data-on-mac.html</loc>
+        <lastmod>2026-06-04</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
 </urlset>


### PR DESCRIPTION
Adds the EXIF/metadata-removal landing page (#6), targeting the privacy long-tail cluster that GSC shows as the site's most winnable queries. Follows the existing guide template (meta, OG, BreadcrumbList + Article + FAQPage JSON-LD, no-JS reveal), is added to the sitemap, and is cross-linked from the two highest-impression pages.

Verified in preview: valid structure, three JSON-LD blocks parse, no broken internal links.

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)